### PR TITLE
Add prompt=none to the oauth2 URL

### DIFF
--- a/app.py
+++ b/app.py
@@ -125,6 +125,7 @@ async def login(request):
         "client_id": OAUTH2_CLIENT_ID,
         "response_type": "code",
         "redirect_uri": OAUTH2_REDIRECT_URI,
+        "prompt": "none"
     }
 
     return response.redirect(f"{AUTHORIZATION_BASE_URL}?{urlencode(data)}")


### PR DESCRIPTION
Reduces the pain of clicking on modmail archive URLs by not prompting for authorisation if previously authorised